### PR TITLE
Update optimize_pdfs.py

### DIFF
--- a/optimize_pdfs.py
+++ b/optimize_pdfs.py
@@ -278,7 +278,7 @@ def delete_metadata(my_pdf, remove_js):
 
     # Remove from the document root
     for name in UNDESIRED_NAMES:
-        delete_name(my_pdf.root, name)
+        delete_name(my_pdf.Root, name)
 
     # FIXME: The following may be useless with the deletions above
     # Remove the only /Title that we want
@@ -290,7 +290,7 @@ def delete_metadata(my_pdf, remove_js):
         delete_name(my_pdf.docinfo, key, -1)
 
     # FIXME: This doesn't seem to work
-    delete_name(my_pdf.root, '/Info')
+    delete_name(my_pdf.Root, '/Info')
     # FIXME: This does
     delete_name(my_pdf.trailer, '/Info', -2)
 


### PR DESCRIPTION
Had to use `.Root` instead of `.root` when using the latest version of pikepdf.  The deprecation of `.root` was mentioned in their release notes at: https://pikepdf.readthedocs.io/en/latest/release_notes.html#id1

> Deprecated or private functions were removed: - Object.page_contents_* (use Page.contents_*) - Object.images (use Page.images) - Page._attach (use the new attachment API) - Stream(obj=) (deprecated obj parameter removed) - Pdf.root (use Pdf.Root) - Pdf._process (use Pdf.open(BytesIO(...)) instead)

Other than this issue, I really appreciate you putting this script together.  It's been a real gem in terms of cleaning up files.